### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/brian-testing-190724/ac20ef04-245a-4c11-8fde-a328d0241d18/ad4e194e-a458-49db-97bf-c11fa6bc8ec5/_apis/work/boardbadge/331cd205-e9ce-4310-acf9-1b26f1130b56)](https://dev.azure.com/brian-testing-190724/ac20ef04-245a-4c11-8fde-a328d0241d18/_boards/board/t/ad4e194e-a458-49db-97bf-c11fa6bc8ec5/Microsoft.RequirementCategory)
 # Simple Feed Reader
 
 This is a sample application used for [Azure guidance](https://docs.microsoft.com/aspnet/core/azure/?view=aspnetcore-2.1) tutorials.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/brian-testing-190724/ac20ef04-245a-4c11-8fde-a328d0241d18/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.